### PR TITLE
Modified build to update Hibernate version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsVersion"
         classpath "com.bertramlabs.plugins:asset-pipeline-gradle:2.14.2"
+        classpath "org.grails.plugins:hibernate5:6.0.2"
     }
 }
 
@@ -39,7 +40,9 @@ dependencies {
     provided "org.grails:grails-plugin-services"
     provided "org.grails:grails-plugin-domain-class"
     runtime "com.bertramlabs.plugins:asset-pipeline-grails:2.14.2"
-    compile "org.grails.plugins:hibernate4:5.0.0.RC1"
+    compile "org.grails.plugins:hibernate5"
+    compile "org.hibernate:hibernate-core:5.1.1.Final"
+    compile "org.hibernate:hibernate-ehcache:5.1.1.Final"
     testCompile "org.grails:grails-plugin-testing"
     testCompile "org.grails.plugins:geb"
     testRuntime "org.seleniumhq.selenium:selenium-htmlunit-driver:2.47.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Nov 27 23:09:32 CET 2015
+#Wed Jul 26 19:29:35 CDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip


### PR DESCRIPTION
This allows the project to build, however, the tests are not currently being recognized.  You may have to either update a reference to JUnit, or possibly convert the tests to spock framework.  If you need to do the later I will be happy to help.